### PR TITLE
Fix meta args cascade arguments

### DIFF
--- a/main.c
+++ b/main.c
@@ -61,6 +61,32 @@
 		if (f) {fprintf(stderr, args);  return -1;}	\
 	} while(0)
 
+#define META_ARGS(else_cnd)                                                     \
+	if (!strcmp(aa, "--file")) {                                        \
+		TRY(i + 3 >= ac, "file name require");                          \
+		++incr;                                                         \
+		aa = read_file(files_cnt, av[i + 3], 0);                        \
+		STRY(!aa);                                                      \
+	} else if (!strcmp(aa, "--jsonstr-file")) {                         \
+		TRY(i + 3 >= ac, "file name require");                          \
+		++incr;                                                         \
+		aa = read_file(files_cnt, av[i + 3], 1);                        \
+		STRY(!aa);                                                      \
+	} else if (!strcmp(aa, "--var")) {                                  \
+		TRY(i + 3 >= ac, "var name require");                           \
+		int var_found = 0;                                              \
+		for (int j = 0; j < nb_cli_vars; ++j) {                         \
+			if (!strcmp(cli_vars[j].name, av[i + 3])) {                 \
+				var_found = 1;                                          \
+				aa = cli_vars[j].val;                                   \
+			}                                                           \
+		}                                                               \
+		TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]); \
+		++incr;                                                         \
+		STRY(!aa);                                                      \
+	} else \
+		else_cnd
+
 
 #define VAR_NAME_SIZE 128
 #define VAR_VAL_SIZE 512
@@ -10065,7 +10091,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -10081,32 +10108,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "ClientGatewayId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -10240,7 +10242,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -10256,32 +10259,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -10403,7 +10381,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -10419,32 +10398,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Description")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -10586,7 +10540,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -10602,32 +10557,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Description")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -10780,7 +10710,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -10796,32 +10727,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "BlockDeviceMappings")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -11073,7 +10979,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -11089,32 +10996,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -11236,7 +11118,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -11252,32 +11135,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -11388,7 +11246,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -11404,32 +11263,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -11534,7 +11368,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -11550,32 +11385,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -11687,7 +11497,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -11703,32 +11514,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -11839,7 +11625,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -11855,32 +11642,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -11980,7 +11742,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -11996,32 +11759,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -12137,7 +11875,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -12153,32 +11892,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DestinationIpRange")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -12333,7 +12047,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -12349,32 +12064,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Description")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -12510,7 +12200,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -12526,32 +12217,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AddRouteTableIds")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -12666,7 +12332,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -12682,32 +12349,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DhcpOptionsSetId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -12807,7 +12449,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -12823,32 +12466,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AccessLog")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -13058,7 +12676,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -13074,32 +12693,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -13210,7 +12804,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -13226,32 +12821,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Description")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -13374,7 +12944,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -13390,32 +12961,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DeleteOnVmDeletion")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -13520,7 +13066,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -13536,32 +13083,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DirectLinkInterfaceId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -13661,7 +13183,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -13677,32 +13200,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DedicatedGroupId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -13802,7 +13300,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -13818,32 +13317,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "CaId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -13943,7 +13417,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -13959,32 +13434,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "ApiAccessRuleId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -14123,7 +13573,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -14139,32 +13590,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -14269,7 +13695,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -14285,32 +13712,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AdditionalEmails")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -14533,7 +13935,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -14549,32 +13952,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AccessKeyId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -14696,7 +14074,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -14712,32 +14091,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -14842,7 +14196,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -14858,32 +14213,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -14983,7 +14313,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -14999,32 +14330,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -15113,7 +14419,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -15129,32 +14436,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -15254,7 +14536,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -15270,32 +14553,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -15397,7 +14655,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -15413,32 +14672,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -15538,7 +14772,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -15554,32 +14789,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -15668,7 +14878,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -15684,32 +14895,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -15809,7 +14995,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -15825,32 +15012,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "BackendIps")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -15965,7 +15127,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -15981,32 +15144,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -16106,7 +15244,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -16122,32 +15261,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -16236,7 +15350,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -16252,32 +15367,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -16384,7 +15474,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -16400,32 +15491,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -16516,7 +15582,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -16532,32 +15599,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "PolicyOrn")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -16641,7 +15683,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -16657,32 +15700,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -16782,7 +15800,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -16798,32 +15817,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -16923,7 +15917,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -16939,32 +15934,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -17086,7 +16056,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -17102,32 +16073,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -17216,7 +16162,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -17232,32 +16179,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "BackendVmIds")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -17359,7 +16281,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -17375,32 +16298,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -17491,7 +16389,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -17507,32 +16406,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -17655,7 +16529,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -17671,32 +16546,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -17819,7 +16669,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -17835,32 +16686,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AllVms")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -17999,7 +16825,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -18015,32 +16842,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "BackendVmIds")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -18142,7 +16944,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -18158,32 +16961,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -18306,7 +17084,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -18322,32 +17101,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -18470,7 +17224,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -18486,32 +17241,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -18612,7 +17342,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -18628,32 +17359,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -18754,7 +17460,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -18770,32 +17477,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -18918,7 +17600,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -18934,32 +17617,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -19037,7 +17695,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -19053,32 +17712,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -19178,7 +17812,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -19194,32 +17829,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -19342,7 +17952,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -19358,32 +17969,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -19494,7 +18080,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -19510,32 +18097,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -19657,7 +18219,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -19673,32 +18236,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -19798,7 +18336,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -19814,32 +18353,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -19962,7 +18476,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -19978,32 +18493,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -20126,7 +18616,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -20142,32 +18633,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -20290,7 +18756,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -20306,32 +18773,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -20454,7 +18896,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -20470,32 +18913,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -20618,7 +19036,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -20634,32 +19053,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -20760,7 +19154,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -20776,32 +19171,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -20924,7 +19294,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -20940,32 +19311,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AccessKeyId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -21054,7 +19400,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -21070,32 +19417,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -21218,7 +19540,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -21234,32 +19557,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -21337,7 +19635,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -21353,32 +19652,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -21501,7 +19775,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -21517,32 +19792,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -21665,7 +19915,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -21681,32 +19932,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -21806,7 +20032,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -21822,32 +20049,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -21925,7 +20127,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -21941,32 +20144,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -22089,7 +20267,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -22105,32 +20284,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "FirstItem")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -22225,7 +20379,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -22241,32 +20396,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "PolicyOrn")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -22350,7 +20480,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -22366,32 +20497,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "PolicyOrn")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -22464,7 +20570,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -22480,32 +20587,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -22628,7 +20710,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -22644,32 +20727,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -22770,7 +20828,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -22786,32 +20845,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -22934,7 +20968,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -22950,32 +20985,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -23098,7 +21108,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -23114,32 +21125,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -23262,7 +21248,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -23278,32 +21265,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -23426,7 +21388,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -23442,32 +21405,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -23590,7 +21528,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -23606,32 +21545,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -23765,7 +21679,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -23781,32 +21696,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -23906,7 +21796,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -23922,32 +21813,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -24048,7 +21914,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -24064,32 +21931,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -24180,7 +22022,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -24196,32 +22039,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -24322,7 +22140,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -24338,32 +22157,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -24497,7 +22291,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -24513,32 +22308,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -24661,7 +22431,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -24677,32 +22448,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -24825,7 +22571,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -24841,32 +22588,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -24989,7 +22711,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -25005,32 +22728,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -25153,7 +22851,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -25169,32 +22868,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -25295,7 +22969,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -25311,32 +22986,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -25414,7 +23064,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -25430,32 +23081,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -25578,7 +23204,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -25594,32 +23221,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -25742,7 +23344,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -25758,32 +23361,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -25906,7 +23484,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -25922,32 +23501,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -26070,7 +23624,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -26086,32 +23641,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -26243,7 +23773,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -26259,32 +23790,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -26373,7 +23879,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -26389,32 +23896,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -26537,7 +24019,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -26553,32 +24036,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -26679,7 +24137,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -26695,32 +24154,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -26798,7 +24232,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -26814,32 +24249,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -26940,7 +24350,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -26956,32 +24367,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -27127,7 +24513,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -27143,32 +24530,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -27269,7 +24631,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -27285,32 +24648,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -27388,7 +24726,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -27404,32 +24743,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -27518,7 +24832,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -27534,32 +24849,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -27637,7 +24927,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -27653,32 +24944,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -27790,7 +25056,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -27806,32 +25073,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -27953,7 +25195,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -27969,32 +25212,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DeviceName")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -28105,7 +25323,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -28121,32 +25340,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -28246,7 +25440,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -28262,32 +25457,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -28387,7 +25557,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -28403,32 +25574,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AllowRelink")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -28577,7 +25723,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -28593,32 +25740,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AllowRelink")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -28747,7 +25869,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -28763,32 +25886,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -28888,7 +25986,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -28904,32 +26003,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DeviceNumber")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -29040,7 +26114,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -29056,32 +26131,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -29181,7 +26231,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -29197,32 +26248,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "BackendIps")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -29337,7 +26363,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -29353,32 +26380,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -29478,7 +26480,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -29494,32 +26497,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -29619,7 +26597,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -29635,32 +26614,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "BackendVmIds")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -29762,7 +26716,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -29778,32 +26733,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DestinationIpRange")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -29903,7 +26833,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -29919,32 +26850,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -30033,7 +26939,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -30049,32 +26956,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -30163,7 +27045,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -30179,32 +27062,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -30295,7 +27153,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -30311,32 +27170,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -30425,7 +27259,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -30441,32 +27276,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -30555,7 +27365,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -30571,32 +27382,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -30685,7 +27471,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -30701,32 +27488,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -30837,7 +27599,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -30853,32 +27616,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -30994,7 +27732,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -31010,32 +27749,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -31124,7 +27838,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -31140,32 +27855,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -31287,7 +27977,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -31303,32 +27994,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -31417,7 +28083,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -31433,32 +28100,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -31547,7 +28189,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -31563,32 +28206,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -31677,7 +28295,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -31693,32 +28312,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -31915,7 +28509,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -31931,32 +28526,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -32056,7 +28626,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -32072,32 +28643,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -32186,7 +28732,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -32202,32 +28749,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DestinationIpRange")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -32327,7 +28849,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -32343,32 +28866,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -32468,7 +28966,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -32484,32 +28983,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "PolicyOrn")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -32593,7 +29067,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -32609,32 +29084,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -32723,7 +29173,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -32739,32 +29190,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -32853,7 +29279,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -32869,32 +29296,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -32983,7 +29385,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -32999,32 +29402,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -33113,7 +29491,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -33129,32 +29508,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -33243,7 +29597,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -33259,32 +29614,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -33373,7 +29703,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -33389,32 +29720,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -33536,7 +29842,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -33552,32 +29859,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -33677,7 +29959,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -33693,32 +29976,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -33820,7 +30078,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -33836,32 +30095,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -33950,7 +30184,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -33966,32 +30201,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -34080,7 +30290,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -34096,32 +30307,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -34210,7 +30396,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -34226,32 +30413,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -34340,7 +30502,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -34356,32 +30519,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -34470,7 +30608,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -34486,32 +30625,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -34600,7 +30714,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -34616,32 +30731,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -34730,7 +30820,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -34746,32 +30837,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DirectLinkInterfaceId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -34860,7 +30926,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -34876,32 +30943,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DirectLinkId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -34990,7 +31032,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -35006,32 +31049,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DhcpOptionsSetId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -35120,7 +31138,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -35136,32 +31155,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DedicatedGroupId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -35266,7 +31260,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -35282,32 +31277,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "ClientGatewayId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -35396,7 +31366,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -35412,32 +31383,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "CaId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -35526,7 +31472,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -35542,32 +31489,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "ApiAccessRuleId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -35656,7 +31578,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -35672,32 +31595,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AccessKeyId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -35797,7 +31695,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -35813,32 +31712,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DestinationIpRange")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -35938,7 +31812,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -35954,32 +31829,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "ClientGatewayId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -36106,7 +31956,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -36122,32 +31973,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -36280,7 +32106,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -36296,32 +32123,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "BlockDeviceMappings")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -36697,7 +32499,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -36713,32 +32516,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "CpuCores")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -36935,7 +32713,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -36951,32 +32730,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Description")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -37164,7 +32918,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -37180,32 +32935,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "ConnectionType")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -37294,7 +33024,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -37310,32 +33041,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -37435,7 +33141,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -37451,32 +33158,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -37576,7 +33258,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -37592,32 +33275,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -37739,7 +33397,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -37755,32 +33414,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -37891,7 +33525,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -37907,32 +33542,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -38044,7 +33654,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -38060,32 +33671,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Description")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -38229,7 +33815,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -38245,32 +33832,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Body")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -38403,7 +33965,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -38419,32 +33982,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -38641,7 +34179,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -38657,32 +34196,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Description")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -38793,7 +34307,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -38809,32 +34324,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -38923,7 +34413,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -38939,32 +34430,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DestinationIpRange")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -39119,7 +34585,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -39135,32 +34602,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -39238,7 +34680,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -39254,32 +34697,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Description")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -39379,7 +34797,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -39395,32 +34814,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Document")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -39520,7 +34914,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -39536,32 +34931,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Description")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -39683,7 +35053,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -39699,32 +35070,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Description")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -39868,7 +35214,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -39884,32 +35231,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AccepterNetId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -40009,7 +35331,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -40025,32 +35348,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -40163,7 +35461,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -40179,32 +35478,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -40304,7 +35578,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -40320,32 +35595,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "ClientToken")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -40456,7 +35706,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -40472,32 +35723,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -40619,7 +35845,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -40635,32 +35862,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "CookieExpirationPeriod")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -40793,7 +35995,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -40809,32 +36012,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -40954,7 +36132,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -40970,32 +36149,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -41207,7 +36361,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -41223,32 +36378,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -41385,7 +36515,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -41401,32 +36532,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -41526,7 +36632,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -41542,32 +36649,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -41645,7 +36727,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -41661,32 +36744,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -41798,7 +36856,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -41814,32 +36873,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Architecture")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -42065,7 +37099,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -42081,32 +37116,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DeleteOnVmDeletion")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -42233,7 +37243,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -42249,32 +37260,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DirectLinkId")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -42386,7 +37372,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -42402,32 +37389,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "Bandwidth")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -42538,7 +37500,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -42554,32 +37517,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DomainName")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -42707,7 +37645,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -42723,32 +37662,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "CpuGeneration")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -42859,7 +37773,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -42875,32 +37790,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "BgpAsn")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -43011,7 +37901,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -43027,32 +37918,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "CaPem")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -43152,7 +38018,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -43168,32 +38035,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "CaIds")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -43321,7 +38163,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -43337,32 +38180,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "AdditionalEmails")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -43596,7 +38414,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -43612,32 +38431,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -43737,7 +38531,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -43753,32 +38548,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -43878,7 +38648,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -43894,32 +38665,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');
@@ -44041,7 +38787,8 @@ int main(int ac, char **av)
 			      	  incr = 1;
 				  aa = eq_ptr + 1;
 			   } else {
-			     	  CHK_BAD_RET(!aa || aa[0] == '-', "cascade need an argument\n");
+			     	  CHK_BAD_RET(!aa, "cascade need an argument\n");
+					  META_ARGS({CHK_BAD_RET(aa[0] == '-', "cascade need an argument"); })
 			   }
 		      	   STRY(cascade_parser(cascade_struct, next_a, aa, pa));
 			   i += incr;
@@ -44057,32 +38804,7 @@ int main(int ac, char **av)
 
 			     (void)str;
 			     if (aa && aa[0] == '-' && aa[1] == '-' && aa[2] != '-') {
-				if (!strcmp(aa, "--file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 0);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--jsonstr-file")) {
-				   	TRY(i + 3 >= ac, "file name require");
-					++incr;
-					aa = read_file(files_cnt, av[i + 3], 1);
-					STRY(!aa);
-				} else if (!strcmp(aa, "--var")) {
-				   	TRY(i + 3 >= ac, "var name require");
-					int var_found = 0;
-					for (int j = 0; j < nb_cli_vars; ++j) {
-					    if (!strcmp(cli_vars[j].name, av[i + 3])) {
-						var_found = 1;
-						aa = cli_vars[j].val;
-					    }
-					}
-					TRY(!var_found, "--var could not find osc variable '%s'", av[i + 3]);
-					++incr;
-					STRY(!aa);
-				} else {
-					aa = 0;
-					incr = 1;
-				}
+				 	META_ARGS({ aa = 0; incr = 1; });
 			     }
 			      if ((aret = argcmp(next_a, "DryRun")) == 0 || aret == '=' ) {
 			      	 char *eq_ptr = strchr(next_a, '=');


### PR DESCRIPTION
Add support for `--var` and other inside cascade notation.
For example: `CreateTags --ResourceIds[] --var net --Tags.0.Key "test" ..Value --var net`