### PR TITLE
📝 docs: update README to reflect project deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # oapi-cli
 
-[![Project Incubating](https://docs.outscale.com/fr/userguide/_images/Project-Incubating-blue.svg)](https://docs.outscale.com/en/userguide/Open-Source-Projects.html)
+[![Project Archived](https://docs.outscale.com/fr/userguide/_images/Project-Archived-red.svg)](https://docs.outscale.com/en/userguide/Open-Source-Projects.html)
 [![](https://dcbadge.limes.pink/api/server/HUVtY5gT6s?style=flat&theme=default-inverted)](https://discord.gg/HUVtY5gT6s)
 
 <p align="center">
@@ -8,6 +8,12 @@
 </p>
 
 ---
+
+> [!WARNING]
+> 
+> `oapi-cli` is deprecated and is no longer actively maintained.
+>
+> We recommend using [`octl`](https://github.com/outscale/octl) instead. `octl` is our latest CLI project and is actively maintained.
 
 ## 🌐 Links
 


### PR DESCRIPTION
# update README to reflect project deprecation and recommend using octl

## Description

oapi-cli is deprecated, long live to octl

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [x] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

Commands used (if applicable):


## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
